### PR TITLE
Implement "listprojects" and "listcontexts" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
         - [Clean up the list](#clean-up-the-list)
         - [Modify todo list](#modify-todo-list)
         - [Use human-readable dates](#use-human-readable-dates)
+        - [Show all project or context tags](#show-all-project-or-context-tags)
 
 # TTDL (Terminal ToDo List)
 
@@ -191,6 +192,8 @@ Commands:
 * stop - stop todo's timer and update time spent on the todo;
 * stats - display todo statistics: total number of todos, done and overdue ones, spent time, and detailed statistics grouped by project and context.
 * postpone - push task's due date (modifies only incomplete tasks with due date defined), argument is the number of days/weeks/months/years to push the date in format: single digit and d/w/m/y without a space between them
+* listprojects - show list of all project tags. Filters used by "list" are supported;
+* listcontexts - show list of all context tags. Filters used by "list" are supported;
 
 Most of the commands can be abbreviated. Please refer to built-in TTDL help to get a list of full command names and their aliases.
 
@@ -528,3 +531,14 @@ All examples are for the current date `2020-07-11`
 | `ttdl "update docs t:1m d:1m2w"` | Adds a new todo with a content `update docs t:2020-08-11 due:2020-08-25` |
 | `ttdl e 3 --set-due 1m` | Updates the third todo with new due date `2020-08-11` |
 | `ttdl e 3 --set-due 1m` | For the current date `2020-02-29` it sets due date to the end of the next month `2020-03-31` |
+
+### Show all project or context tags
+
+| Command | Description |
+|---|---|
+| `ttdl lc ` | show all context tags |
+| `ttdl listcon @phone*` | show all context tags starting with phone |
+| `ttdl lp ` | show all project tags |
+| `ttdl listproj +*car*` | show all project tags containg *car* |
+
+These commands could be used to implement tag completion in your editor / shell.

--- a/changelog
+++ b/changelog
@@ -5,6 +5,9 @@ ttdl (0.9.0) unstable; urgency=medium
     commands. Since this version it is possible to, e.g., write "due:1w"
     to set the due date in a week from the current date.
 
+  * New commands 'listprojects' and 'listcontexts' to list all
+    project/context tags. Supports the same filters as the "list" command.
+
  -- Vladimir Markelov <vmatroskin@gmail.com>  Sat, 11 Jul 2020 12:43:11 -0700
 
 ttdl (0.8.0) unstable; urgency=medium

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -39,6 +39,8 @@ pub enum RunMode {
     Stop,
     Stats,
     Postpone,
+    ListProjects,
+    ListContexts,
 }
 
 #[derive(Debug, Clone)]
@@ -141,6 +143,12 @@ fn print_usage(program: &str, opts: &Options) {
         `ttdl e @bug1000 --set-pri=+` - increase priority for all incomplete todos which have context `bug1000`, todos which did not have priority set get the lowest priority `z`
     append | app - adds a text to the end of todos
     prepend | prep - inserts a text at the beginning of todos
+    listprojects [FILTER] | listproj | lp - list all projects
+        `ttdl lp ` - show alphabetically sorted list of all projects
+        `ttdl lp +un*` - show projects starting with 'un'
+    listcontexts [FILTER] | listcon | lc - list all contexts
+        `ttdl lc ` - show alphabetically sorted list of all contexts
+        `ttdl lc @phon*` - show contexts starting with 'phon'
     "#;
     println!("{}\n\n{}\n\n{}\n\n{}", commands, filter, newones, extras);
 }
@@ -160,6 +168,8 @@ fn str_to_mode(s: &str) -> RunMode {
         "stop" => RunMode::Stop,
         "stats" => RunMode::Stats,
         "postpone" => RunMode::Postpone,
+        "lp" | "listproj" | "listprojects" => RunMode::ListProjects,
+        "lc" | "listcon" | "listcontexts" => RunMode::ListContexts,
         _ => RunMode::None,
     }
 }


### PR DESCRIPTION
Useful to get an overview of all projects / contexts in use.
Supports the same filters as the "list" command.

Note: If a task has multiple contexts like "@person @phone"
and you filter for @phon*, you will also get @person
in the output as the filter selects on the task level only.

Feel free to tweak the code to your liking.