### PR TITLE
README.md: Fix human due date example

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,6 +525,6 @@ All examples are for the current date `2020-07-11`
 | Command | Description |
 |---|---|
 | `ttdl "fix by monday due:mon"` | Adds a new todo with a content `fix by monday due:2020-07-13` |
-| `ttdl "update docs t:1m d:1m2w"` | Adds a new todo with a content `update docs t:2020-08-11 due:2020-08-25` |
+| `ttdl "update docs t:1m due:1m2w"` | Adds a new todo with a content `update docs t:2020-08-11 due:2020-08-25` |
 | `ttdl e 3 --set-due 1m` | Updates the third todo with new due date `2020-08-11` |
 | `ttdl e 3 --set-due 1m` | For the current date `2020-02-29` it sets due date to the end of the next month `2020-03-31` |


### PR DESCRIPTION
"d:" is not recognized, it needs to be "due:".

I grepped for "d:" and this was the only occurrence.