### PR TITLE
Add "yesterday" to date range options, fix "tomorrow" to not include "today"

### DIFF
--- a/src/conf.rs
+++ b/src/conf.rs
@@ -310,7 +310,10 @@ fn parse_filter_date_range(val: &str, soon_days: u8) -> Result<tfilter::DateRang
             Ok(tfilter::DateRange { days: tfilter::ValueRange { low: 0, high: 0 }, span: tfilter::ValueSpan::Range })
         }
         "tomorrow" => {
-            Ok(tfilter::DateRange { days: tfilter::ValueRange { low: 0, high: 1 }, span: tfilter::ValueSpan::Range })
+            Ok(tfilter::DateRange { days: tfilter::ValueRange { low: 1, high: 1 }, span: tfilter::ValueSpan::Range })
+        }
+        "yesterday" => {
+            Ok(tfilter::DateRange { days: tfilter::ValueRange { low: -1, high: -1 }, span: tfilter::ValueSpan::Range })
         }
         _ => Err(terr::TodoError::InvalidValue(val.to_string(), "date range".to_string())),
     }


### PR DESCRIPTION
I'm a new user of todo.txt ecosystem, so I'm open for discussion

### Changes
This small changes adds handling of "yesterday" date range and also fixes "tomorrow" date range

### Usecases
Adding "yesterday" allows seeing list of tasks that were completed yesterday.
```sh
ttdl --completed=yesterday -A
```
Fixing "tomorrow" date-range allows seeing tasks that are due tomorrow.
Previously, it would also show tasks that are due today.
```
ttdl --due=tomorrow
```