### PR TITLE
#97 - Allow setting completion date even when creation date is absent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,9 +62,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.0"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaff6f8ce506b9773fa786672d63fc7a191ffea1be33f72bbd4aeacefca9ffc8"
+checksum = "324c74f2155653c90b04f25b2a47a8a631360cb908f92a772695f430c7e31052"
 
 [[package]]
 name = "cfg-if"
@@ -337,9 +337,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.70"
+version = "2.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0209b68b3613b093e0ec905354eccaedcfe83b8cb37cbdeae64026c3064c16"
+checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -376,18 +376,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "f2675633b1499176c2dff06b0856a27976a8f9d436737b4cf4f312d4d91d8bbb"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "d20468752b09f49e909e55a5d338caa8bedf615594e9d80bc4c565d30faf798c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -411,9 +411,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "todo_lib"
-version = "7.1.0"
+version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05a934844f8dd1b2ee81654210b64b573acf6a0d29e1988872bb3cca1cf67dbf"
+checksum = "0b849daca56a0a15668e25476f4f7af963d334988a26c50695469dfd11201267"
 dependencies = [
  "chrono",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ lto = true
 strip = "debuginfo"
 
 [dependencies]
-todo_lib = "7"
+todo_lib = "7.2.0"
 getopts = "^0.2"
 chrono = "^0.4"
 textwrap = "^0.11"

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -69,6 +69,7 @@ pub struct Conf {
     pub auto_show_columns: bool,
     pub always_hide_columns: Vec<String>,
     pub priority_on_done: todotxt::CompletionMode,
+    pub add_completion_date_always: bool,
 
     pub todo: todo::Conf,
     pub fmt: fmt::Conf,
@@ -98,6 +99,7 @@ impl Default for Conf {
             auto_show_columns: false,
             always_hide_columns: Vec::new(),
             priority_on_done: todotxt::CompletionMode::JustMark,
+            add_completion_date_always: false,
 
             fmt: Default::default(),
             todo: Default::default(),
@@ -981,6 +983,9 @@ fn update_global_from_conf(tc: &tml::Conf, conf: &mut Conf) {
             Some(m) => conf.priority_on_done = m,
             None => eprintln!("Invalid value '{l}' for global.priority_on_done"),
         }
+    }
+    if let Some(acda) = &tc.global.add_completion_date_always {
+        conf.add_completion_date_always = *acda;
     }
 }
 

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -1221,6 +1221,11 @@ pub fn parse_args(args: &[String]) -> Result<Conf> {
         "what to do with priority on task completion: keep - no special action(default behavior), move - place priority after completion date, tag - convert priority to a tag 'pri:', erase - remove priority. Notethat in all modes, except `erase`, the operation is reversible and on task uncompleting, the task gets its priority back",
         "VALUE",
     );
+    opts.optflag(
+        "",
+        "add-completion-date-always",
+        "When task is finished, always add completion date, regardless of whether or not creation date is present"
+    );
     opts.optflag("k", "keep-tags", "in edit mode a new subject replaces regular text of the todo, everything else(tags, priority etc) is taken from the old and appended to the new subject. A convenient way to replace just text and keep all the tags without typing the tags again");
 
     let matches: Matches = match opts.parse(&args[1..]) {
@@ -1300,6 +1305,9 @@ pub fn parse_args(args: &[String]) -> Result<Conf> {
                 )))
             }
         }
+    }
+    if matches.opt_present("add-completion-date-always") {
+        conf.add_completion_date_always = true;
     }
 
     let soon_days = conf.fmt.colors.soon_days;

--- a/src/tml.rs
+++ b/src/tml.rs
@@ -35,6 +35,7 @@ pub struct Global {
     pub auto_show_columns: Option<bool>,
     pub always_hide_columns: Option<String>,
     pub priority_on_done: Option<String>,
+    pub add_completion_date_always: Option<bool>,
 }
 
 #[derive(Deserialize)]

--- a/ttdl.toml
+++ b/ttdl.toml
@@ -152,6 +152,14 @@ old = "1y"
 #       task is undone, the task gets its priority back
 # priority_on_done = keep
 
+# How to set completion date when task is finished. The original todo.txt standard
+# states that creation date must be present when completion date is. However, most
+# todo.txt clients allow completed tasks to have only one date, which is completion
+# date.
+#    false  = only add completion date if task has creation date (default)
+#    true   = always add completion date, regardless of creation date is presence
+# add_completion_date_always = false
+
 [syntax]
 # Set enabled to 'true' to highlight projects, contexts, tags, and hashtags
 #     inside the subject


### PR DESCRIPTION
Allowing is done through a tunable in a **config file**, called `add_completion_date_always`. I added a section into the example config that explains how to use it. 

I also added `--add-completion-date-always` **option flag** to override this behavior in CLI. I didn't think of a shorter name because I didn't expect it to be used directly in shell, instead people might use this option when writing scripts that call `ttdl`.

I installed the binary and tested it, I don't think there is a need to write unit tests, because I would essentially be re-testing library functionality.

This pull request is dedicated to issue #97.