### PR TITLE
Opt-in Markdown rendering for task subjects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,7 +650,6 @@ dependencies = [
  "dirs",
  "getopts",
  "json",
- "lazy_static",
  "pulldown-cmark",
  "regex",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83c41efbf8f90ac44de7f3a868f0867851d261b56291732d0cbf7cceaaeb55a6"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,6 +650,8 @@ dependencies = [
  "dirs",
  "getopts",
  "json",
+ "lazy_static",
+ "pulldown-cmark",
  "regex",
  "serde",
  "serde_derive",
@@ -650,6 +663,12 @@ dependencies = [
  "toml",
  "unicode-width",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,11 @@ unicode-width="^0.2"
 anyhow = "1"
 tempfile = "3"
 regex = "1"
-pulldown-cmark = { version = "0.13", default-features = false }
+pulldown-cmark = { version = "0.13", default-features = false, optional = true }
+
+[features]
+default = ["markdown"]
+markdown = ["dep:pulldown-cmark"]
 
 [package.metadata.deb]
 section = "utility"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ unicode-width="^0.2"
 anyhow = "1"
 tempfile = "3"
 regex = "1"
+pulldown-cmark = { version = "0.13", default-features = false }
 
 [package.metadata.deb]
 section = "utility"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
       - [Example](#example)
     - [Extra features](#extra-features)
       - [Syntax highlight](#syntax-highlight)
+      - [Markdown rendering](#markdown-rendering)
       - [Hide duplicated info](#hide-duplicated-info)
       - [Edit in keep-tags mode](#edit-in-keep-tags-mode)
       - [Interactive edit](#interactive-edit)
@@ -1527,6 +1528,32 @@ Besides turning highlighting on and off, the configuration allows tuning the key
 - hashtag color is cyan
 - project color is bright green
 - context color is green
+
+#### Markdown rendering
+
+TTDL can render a subset of Markdown in task subject text using terminal escape codes.
+The feature is disabled by default.
+To enable it, either pass `--markdown` on the command line or set `enabled = true` in the `[markdown]` section of `ttdl.toml`.
+Use `--no-markdown` to temporarily disable it when it is turned on in the configuration file.
+The command-line flag always takes precedence over the configuration file.
+
+Supported formatting:
+
+- `**bold**` — bold text
+- `*italic*` or `_italic_` — italic text
+- `` `code` `` — inline code (highlighted in a configurable color, default yellow)
+- `[link text](url)` — clickable hyperlinks using OSC 8 terminal escape sequences; link text is underlined
+- Bare `https://` and `http://` URLs are automatically turned into clickable hyperlinks
+
+Syntax highlighting of `+projects`, `@contexts`, and `tag:value` fields works alongside Markdown formatting.
+
+Configuration options in `ttdl.toml`:
+
+```toml
+[markdown]
+enabled = true        # set to false to disable (default)
+code_color = "yellow" # color for inline `code` spans
+```
 
 #### Hide duplicated info
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ The application can be compiled from source, or installed using cargo:
 cargo install ttdl
 ```
 
+TTDL includes Markdown rendering support by default. To build without it:
+
+```shell
+cargo install ttdl --no-default-features
+```
+
+When built without the `markdown` feature, the `--markdown` flag is accepted but has no effect.
+
 You need Rust compiler that supports Rust 2018 edition (Rust 1.31 or newer) to do it. If you want to upgrade existing ttdl execute the following command:
 
 ```shell
@@ -1535,6 +1543,7 @@ TTDL can render a subset of Markdown in task subject text using terminal escape 
 The feature is disabled by default.
 To enable it, either pass `--markdown` on the command line or set `enabled = true` in the `[markdown]` section of `ttdl.toml`.
 Use `--no-markdown` to temporarily disable it when it is turned on in the configuration file.
+This feature can be excluded at compile time with `--no-default-features` to remove the `pulldown-cmark` dependency.
 The command-line flag always takes precedence over the configuration file.
 
 Supported formatting:

--- a/src/colauto.rs
+++ b/src/colauto.rs
@@ -82,7 +82,16 @@ fn max_field_width(tasks: &todo::TaskSlice, ids: &todo::IDSlice, field: &str, fi
         } else if default_caseless_match_str(field, "subject") {
             let mut desc = tasks[*id].subject.clone();
             cleanup_description(&mut desc, fields, c);
-            if c.markdown { crate::md::visible_text(&desc).width() } else { desc.width() }
+            {
+                #[cfg(feature = "markdown")]
+                if c.markdown {
+                    crate::md::visible_text(&desc).width()
+                } else {
+                    desc.width()
+                }
+                #[cfg(not(feature = "markdown"))]
+                desc.width()
+            }
         } else if let Some(val) = get_field(&tasks[*id], field, c) {
             val.trim().width()
         } else {

--- a/src/colauto.rs
+++ b/src/colauto.rs
@@ -82,7 +82,7 @@ fn max_field_width(tasks: &todo::TaskSlice, ids: &todo::IDSlice, field: &str, fi
         } else if default_caseless_match_str(field, "subject") {
             let mut desc = tasks[*id].subject.clone();
             cleanup_description(&mut desc, fields, c);
-            desc.width()
+            if c.markdown { crate::md::visible_text(&desc).width() } else { desc.width() }
         } else if let Some(val) = get_field(&tasks[*id], field, c) {
             val.trim().width()
         } else {

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -938,6 +938,18 @@ fn update_syntax_from_config(tc: &tml::Conf, conf: &mut Conf) -> Result<()> {
     Ok(())
 }
 
+fn update_markdown_from_config(tc: &tml::Conf, conf: &mut Conf) -> Result<()> {
+    if let Some(ref cfg) = tc.markdown {
+        if let Some(b) = cfg.enabled {
+            conf.fmt.markdown = b;
+        }
+        if let Some(ref clr) = cfg.code_color {
+            conf.fmt.colors.code = color_from_str(clr)?;
+        }
+    }
+    Ok(())
+}
+
 fn update_fields_from_config(tc: &tml::Conf, conf: &mut Conf) -> Result<()> {
     match tc.fields {
         None => {}
@@ -1175,6 +1187,7 @@ fn load_from_config(conf: &mut Conf, conf_path: Option<PathBuf>) -> Result<()> {
     update_ranges_from_conf(&info_toml, conf);
     update_global_from_conf(&info_toml, conf);
     update_syntax_from_config(&info_toml, conf)?;
+    update_markdown_from_config(&info_toml, conf)?;
     update_fields_from_config(&info_toml, conf)?;
     update_agenda_from_config(&info_toml, conf)?;
     if let Some(strict) = info_toml.global.strict_mode {
@@ -1350,6 +1363,8 @@ pub fn parse_args(args: &[String]) -> Result<Conf> {
     );
     opts.optflag("", "syntax", "Enable keyword highlights when printing subject");
     opts.optflag("", "no-syntax", "Disable keyword highlights when printing subject");
+    opts.optflag("", "markdown", "Enable Markdown formatting in subject text");
+    opts.optflag("", "no-markdown", "Disable Markdown formatting in subject text");
     opts.optflag("", "keep-empty", "do not remove empty todos when cleaning up(archiving) the list");
     opts.optopt(
         "",
@@ -1470,6 +1485,11 @@ pub fn parse_args(args: &[String]) -> Result<Conf> {
         conf.fmt.syntax = true;
     } else if matches.opt_present("no-syntax") {
         conf.fmt.syntax = false;
+    }
+    if matches.opt_present("markdown") {
+        conf.fmt.markdown = true;
+    } else if matches.opt_present("no-markdown") {
+        conf.fmt.markdown = false;
     }
     if let Some(s) = matches.opt_str("clean-subject") {
         conf.fmt.hide = str_to_hide(&s);
@@ -1759,6 +1779,9 @@ fn color_from_str(s: &str) -> Result<ColorSpec> {
             }
             "bold" => {
                 spc.set_bold(true);
+            }
+            "italic" => {
+                spc.set_italic(true);
             }
             _ => return Err(anyhow!("Unknown color '{}'", clr)),
         };

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -938,6 +938,7 @@ fn update_syntax_from_config(tc: &tml::Conf, conf: &mut Conf) -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "markdown")]
 fn update_markdown_from_config(tc: &tml::Conf, conf: &mut Conf) -> Result<()> {
     if let Some(ref cfg) = tc.markdown {
         if let Some(b) = cfg.enabled {
@@ -1187,6 +1188,7 @@ fn load_from_config(conf: &mut Conf, conf_path: Option<PathBuf>) -> Result<()> {
     update_ranges_from_conf(&info_toml, conf);
     update_global_from_conf(&info_toml, conf);
     update_syntax_from_config(&info_toml, conf)?;
+    #[cfg(feature = "markdown")]
     update_markdown_from_config(&info_toml, conf)?;
     update_fields_from_config(&info_toml, conf)?;
     update_agenda_from_config(&info_toml, conf)?;
@@ -1486,6 +1488,7 @@ pub fn parse_args(args: &[String]) -> Result<Conf> {
     } else if matches.opt_present("no-syntax") {
         conf.fmt.syntax = false;
     }
+    #[cfg(feature = "markdown")]
     if matches.opt_present("markdown") {
         conf.fmt.markdown = true;
     } else if matches.opt_present("no-markdown") {

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -55,6 +55,7 @@ pub struct Colors {
     pub tag: ColorSpec,
     pub context: ColorSpec,
     pub project: ColorSpec,
+    pub code: ColorSpec,
     pub default_fg: ColorSpec,
 
     pub important_limit: u8,
@@ -117,6 +118,11 @@ pub(crate) fn default_hashtag_color() -> ColorSpec {
     spc.set_fg(Some(Color::Cyan));
     spc
 }
+pub(crate) fn default_code_color() -> ColorSpec {
+    let mut spc = ColorSpec::new();
+    spc.set_fg(Some(Color::Yellow));
+    spc
+}
 
 impl Default for Colors {
     fn default() -> Colors {
@@ -133,6 +139,7 @@ impl Default for Colors {
             project: default_project_color(),
             tag: default_tag_color(),
             hashtag: default_hashtag_color(),
+            code: default_code_color(),
             default_fg: default_color(),
 
             important_limit: todotxt::NO_PRIORITY,
@@ -429,6 +436,7 @@ pub struct Conf {
     pub script_ext: String,
     pub script_prefix: String,
     pub syntax: bool,
+    pub markdown: bool,
     pub custom_fields: Vec<CustomField>,
     pub custom_names: Vec<String>, // for performance
     pub hide: Hide,
@@ -460,6 +468,7 @@ impl Default for Conf {
             script_prefix: String::new(),
             shell,
             syntax: false,
+            markdown: false,
             custom_fields: Vec::new(),
             custom_names: Vec::new(),
             hide: Hide::Nothing,
@@ -981,7 +990,31 @@ fn print_line(
     }
 
     if !subj_printed {
-        if c.width != 0 && c.long != LongLine::Simple {
+        if c.markdown {
+            if c.width != 0 && c.long != LongLine::Simple {
+                let (skip, subj_w) = calc_width(c, flist, widths);
+                let visible = crate::md::visible_text(&desc);
+                let lines = textwrap::wrap(&visible, subj_w);
+                if c.long == LongLine::Cut || lines.len() == 1 {
+                    crate::md::print_markdown_range(stdout, &desc, 0, lines[0].chars().count(), &fg, c)?;
+                    writeln!(stdout)?;
+                } else {
+                    let mut char_offset = 0usize;
+                    for (i, line) in lines.iter().enumerate() {
+                        if i != 0 {
+                            print_with_color(stdout, &format!("{:width$}", " ", width = skip), &fg)?;
+                        }
+                        let line_len = line.chars().count();
+                        crate::md::print_markdown_range(stdout, &desc, char_offset, line_len, &fg, c)?;
+                        writeln!(stdout)?;
+                        char_offset += line_len;
+                    }
+                }
+            } else {
+                crate::md::print_markdown(stdout, &desc, &fg, c)?;
+                writeln!(stdout)?;
+            }
+        } else if c.width != 0 && c.long != LongLine::Simple {
             let (skip, subj_w) = calc_width(c, flist, widths);
             let lines = textwrap::wrap(&desc, subj_w);
             if c.long == LongLine::Cut || lines.len() == 1 {
@@ -1466,19 +1499,19 @@ fn field_width_cached(field: &str, fields: &[String], cached: &[usize]) -> usize
     0
 }
 
-fn is_hashtag(s: &str) -> bool {
+pub(crate) fn is_hashtag(s: &str) -> bool {
     !s.contains([' ', '\t', '\n', '\r']) && s.len() > 1 && s.starts_with('#')
 }
 
-fn is_project(s: &str) -> bool {
+pub(crate) fn is_project(s: &str) -> bool {
     !s.contains([' ', '\t', '\n', '\r']) && s.len() > 1 && s.starts_with('+')
 }
 
-fn is_context(s: &str) -> bool {
+pub(crate) fn is_context(s: &str) -> bool {
     !s.contains([' ', '\t', '\n', '\r']) && s.len() > 1 && s.starts_with('@')
 }
 
-fn is_tag(s: &str) -> bool {
+pub(crate) fn is_tag(s: &str) -> bool {
     if s.contains([' ', '\t', '\n', '\r']) {
         return false;
     }
@@ -1492,7 +1525,7 @@ fn is_syntax_word(s: &str) -> bool {
     is_hashtag(s) || is_context(s) || is_project(s) || is_tag(s)
 }
 
-fn parse_subj(subj: &str) -> Vec<&str> {
+pub(crate) fn parse_subj(subj: &str) -> Vec<&str> {
     let mut parts: Vec<&str> = Vec::new();
     if !subj.contains([':', '@', '+', '#']) {
         parts.push(subj);

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -55,6 +55,7 @@ pub struct Colors {
     pub tag: ColorSpec,
     pub context: ColorSpec,
     pub project: ColorSpec,
+    #[cfg_attr(not(feature = "markdown"), allow(dead_code))]
     pub code: ColorSpec,
     pub default_fg: ColorSpec,
 
@@ -436,6 +437,7 @@ pub struct Conf {
     pub script_ext: String,
     pub script_prefix: String,
     pub syntax: bool,
+    #[cfg_attr(not(feature = "markdown"), allow(dead_code))]
     pub markdown: bool,
     pub custom_fields: Vec<CustomField>,
     pub custom_names: Vec<String>, // for performance
@@ -990,45 +992,67 @@ fn print_line(
     }
 
     if !subj_printed {
-        if c.markdown {
-            if c.width != 0 && c.long != LongLine::Simple {
-                let (skip, subj_w) = calc_width(c, flist, widths);
-                let visible = crate::md::visible_text(&desc);
-                let lines = textwrap::wrap(&visible, subj_w);
-                if c.long == LongLine::Cut || lines.len() == 1 {
-                    crate::md::print_markdown_range(stdout, &desc, 0, lines[0].chars().count(), &fg, c)?;
-                    writeln!(stdout)?;
+        #[cfg(feature = "markdown")]
+        {
+            if c.markdown {
+                if c.width != 0 && c.long != LongLine::Simple {
+                    let (skip, subj_w) = calc_width(c, flist, widths);
+                    let visible = crate::md::visible_text(&desc);
+                    let lines = textwrap::wrap(&visible, subj_w);
+                    if c.long == LongLine::Cut || lines.len() == 1 {
+                        crate::md::print_markdown_range(stdout, &desc, 0, lines[0].chars().count(), &fg, c)?;
+                        writeln!(stdout)?;
+                    } else {
+                        let mut char_offset = 0usize;
+                        for (i, line) in lines.iter().enumerate() {
+                            if i != 0 {
+                                print_with_color(stdout, &format!("{:width$}", " ", width = skip), &fg)?;
+                            }
+                            let line_len = line.chars().count();
+                            crate::md::print_markdown_range(stdout, &desc, char_offset, line_len, &fg, c)?;
+                            writeln!(stdout)?;
+                            char_offset += line_len;
+                        }
+                    }
                 } else {
-                    let mut char_offset = 0usize;
+                    crate::md::print_markdown(stdout, &desc, &fg, c)?;
+                    writeln!(stdout)?;
+                }
+            } else if c.width != 0 && c.long != LongLine::Simple {
+                let (skip, subj_w) = calc_width(c, flist, widths);
+                let lines = textwrap::wrap(&desc, subj_w);
+                if c.long == LongLine::Cut || lines.len() == 1 {
+                    print_with_highlight(stdout, &format!("{}\n", &lines[0]), &fg, c)?;
+                } else {
                     for (i, line) in lines.iter().enumerate() {
                         if i != 0 {
-                            print_with_color(stdout, &format!("{:width$}", " ", width = skip), &fg)?;
+                            print_with_highlight(stdout, &format!("{:width$}", " ", width = skip), &fg, c)?;
                         }
-                        let line_len = line.chars().count();
-                        crate::md::print_markdown_range(stdout, &desc, char_offset, line_len, &fg, c)?;
-                        writeln!(stdout)?;
-                        char_offset += line_len;
+                        print_with_highlight(stdout, &format!("{}\n", &line), &fg, c)?;
                     }
                 }
             } else {
-                crate::md::print_markdown(stdout, &desc, &fg, c)?;
-                writeln!(stdout)?;
+                print_with_highlight(stdout, &format!("{}\n", &desc), &fg, c)?;
             }
-        } else if c.width != 0 && c.long != LongLine::Simple {
-            let (skip, subj_w) = calc_width(c, flist, widths);
-            let lines = textwrap::wrap(&desc, subj_w);
-            if c.long == LongLine::Cut || lines.len() == 1 {
-                print_with_highlight(stdout, &format!("{}\n", &lines[0]), &fg, c)?;
-            } else {
-                for (i, line) in lines.iter().enumerate() {
-                    if i != 0 {
-                        print_with_highlight(stdout, &format!("{:width$}", " ", width = skip), &fg, c)?;
+        }
+        #[cfg(not(feature = "markdown"))]
+        {
+            if c.width != 0 && c.long != LongLine::Simple {
+                let (skip, subj_w) = calc_width(c, flist, widths);
+                let lines = textwrap::wrap(&desc, subj_w);
+                if c.long == LongLine::Cut || lines.len() == 1 {
+                    print_with_highlight(stdout, &format!("{}\n", &lines[0]), &fg, c)?;
+                } else {
+                    for (i, line) in lines.iter().enumerate() {
+                        if i != 0 {
+                            print_with_highlight(stdout, &format!("{:width$}", " ", width = skip), &fg, c)?;
+                        }
+                        print_with_highlight(stdout, &format!("{}\n", &line), &fg, c)?;
                     }
-                    print_with_highlight(stdout, &format!("{}\n", &line), &fg, c)?;
                 }
+            } else {
+                print_with_highlight(stdout, &format!("{}\n", &desc), &fg, c)?;
             }
-        } else {
-            print_with_highlight(stdout, &format!("{}\n", &desc), &fg, c)?;
         }
     } else {
         print_with_highlight(stdout, "\n", &fg, c)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod cal;
 mod colauto;
 mod conf;
 mod fmt;
+mod md;
 mod stats;
 mod subj_clean;
 mod tml;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod cal;
 mod colauto;
 mod conf;
 mod fmt;
+#[cfg(feature = "markdown")]
 mod md;
 mod stats;
 mod subj_clean;

--- a/src/md.rs
+++ b/src/md.rs
@@ -1,0 +1,332 @@
+//! Markdown rendering for task subject text.
+//!
+//! Provides terminal-aware rendering of a CommonMark subset:
+//! bold, italic, inline code, and links — with optional OSC 8 hyperlinks
+//! and syntax highlighting of `+projects`, `@contexts`, and `tag:value` fields.
+
+use std::io;
+use std::sync::OnceLock;
+
+use pulldown_cmark::{Event, Options, Parser, Tag, TagEnd};
+use regex::Regex;
+use termcolor::{ColorSpec, HyperlinkSpec, StandardStream, WriteColor};
+
+use crate::fmt;
+
+fn bare_url_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"https?://\S+").unwrap())
+}
+
+/// Returns the visible text that a terminal would display after markdown rendering.
+/// Strips all formatting — used for width calculation and wrapping.
+pub fn visible_text(input: &str) -> String {
+    let parser = Parser::new_ext(input, Options::empty());
+    let mut out = String::new();
+    for event in parser {
+        match event {
+            Event::Text(t) => out.push_str(&t),
+            Event::Code(t) => out.push_str(&t),
+            Event::SoftBreak | Event::HardBreak => out.push(' '),
+            _ => {}
+        }
+    }
+    out
+}
+
+/// Merges bold/italic/underline from the markdown style stack into a base ColorSpec.
+fn merge_md_style(base: &ColorSpec, bold: bool, italic: bool, underline: bool) -> ColorSpec {
+    let mut spc = base.clone();
+    if bold {
+        spc.set_bold(true);
+    }
+    if italic {
+        spc.set_italic(true);
+    }
+    if underline {
+        spc.set_underline(true);
+    }
+    spc
+}
+
+/// Writes `text` with syntax highlighting (projects, contexts, tags, hashtags)
+/// while preserving bold/italic/underline from the markdown stack.
+fn write_text_with_syntax(
+    stdout: &mut StandardStream,
+    text: &str,
+    base: &ColorSpec,
+    bold: bool,
+    italic: bool,
+    underline: bool,
+    c: &fmt::Conf,
+) -> io::Result<()> {
+    let merged = merge_md_style(base, bold, italic, underline);
+    if !c.syntax {
+        write_text_with_urls(stdout, text, &merged, c)?;
+        return Ok(());
+    }
+    let words = fmt::parse_subj(text);
+    for word in words.iter() {
+        let word_color = if fmt::is_project(word) {
+            merge_md_style(&c.colors.project, bold, italic, underline)
+        } else if fmt::is_hashtag(word) {
+            merge_md_style(&c.colors.hashtag, bold, italic, underline)
+        } else if fmt::is_context(word) {
+            merge_md_style(&c.colors.context, bold, italic, underline)
+        } else if fmt::is_tag(word) {
+            merge_md_style(&c.colors.tag, bold, italic, underline)
+        } else {
+            merged.clone()
+        };
+        write_text_with_urls(stdout, word, &word_color, c)?;
+    }
+    Ok(())
+}
+
+/// Writes text, wrapping bare URLs in OSC 8 hyperlinks when running in a terminal.
+fn write_text_with_urls(stdout: &mut StandardStream, text: &str, color: &ColorSpec, c: &fmt::Conf) -> io::Result<()> {
+    if !c.atty || c.color_term == fmt::TermColorType::None {
+        stdout.set_color(color)?;
+        write!(stdout, "{text}")?;
+        return Ok(());
+    }
+
+    let mut last = 0;
+    for m in bare_url_re().find_iter(text) {
+        if m.start() > last {
+            stdout.set_color(color)?;
+            write!(stdout, "{}", &text[last..m.start()])?;
+        }
+        let url = m.as_str();
+        let mut url_color = color.clone();
+        url_color.set_underline(true);
+        stdout.set_hyperlink(&HyperlinkSpec::open(url.as_bytes()))?;
+        stdout.set_color(&url_color)?;
+        write!(stdout, "{url}")?;
+        stdout.set_hyperlink(&HyperlinkSpec::close())?;
+        last = m.end();
+    }
+    if last < text.len() {
+        stdout.set_color(color)?;
+        write!(stdout, "{}", &text[last..])?;
+    }
+    Ok(())
+}
+
+/// Renders markdown-formatted text to the terminal with ANSI styling.
+///
+/// Supports bold, italic, inline code, links, and bare URLs.
+/// When `c.syntax` is true, also highlights +projects, @contexts, #hashtags, and tags.
+pub fn print_markdown(stdout: &mut StandardStream, text: &str, base: &ColorSpec, c: &fmt::Conf) -> io::Result<()> {
+    let parser = Parser::new_ext(text, Options::empty());
+    let mut bold = false;
+    let mut italic = false;
+    let mut in_link = false;
+
+    for event in parser {
+        match event {
+            Event::Start(Tag::Emphasis) => italic = true,
+            Event::Start(Tag::Strong) => bold = true,
+            Event::Start(Tag::Link { dest_url, .. }) => {
+                in_link = true;
+                if c.atty && c.color_term != fmt::TermColorType::None {
+                    stdout.set_hyperlink(&HyperlinkSpec::open(dest_url.as_bytes()))?;
+                }
+            }
+            Event::End(TagEnd::Emphasis) => italic = false,
+            Event::End(TagEnd::Strong) => bold = false,
+            Event::End(TagEnd::Link) => {
+                if c.atty && c.color_term != fmt::TermColorType::None {
+                    stdout.set_hyperlink(&HyperlinkSpec::close())?;
+                }
+                in_link = false;
+            }
+            Event::Code(t) => {
+                let code_color = merge_md_style(&c.colors.code, bold, italic, in_link);
+                stdout.set_color(&code_color)?;
+                write!(stdout, "{t}")?;
+            }
+            Event::Text(t) => {
+                if in_link {
+                    // Inside a link — `in_link` maps to underline in merge_md_style
+                    let merged = merge_md_style(base, bold, italic, true);
+                    stdout.set_color(&merged)?;
+                    write!(stdout, "{t}")?;
+                } else {
+                    write_text_with_syntax(stdout, &t, base, bold, italic, false, c)?;
+                }
+            }
+            Event::SoftBreak | Event::HardBreak => {
+                write!(stdout, " ")?;
+            }
+            _ => {} // Ignore block-level events
+        }
+    }
+
+    Ok(())
+}
+
+/// Renders a range of markdown text by visible character count.
+///
+/// Skips the first `skip` visible characters, then renders up to `limit`
+/// visible characters. Used for wrapped/cut lines: line 1 uses skip=0,
+/// line 2 uses skip=len(line1), etc.
+pub fn print_markdown_range(
+    stdout: &mut StandardStream,
+    text: &str,
+    skip: usize,
+    limit: usize,
+    base: &ColorSpec,
+    c: &fmt::Conf,
+) -> io::Result<()> {
+    let parser = Parser::new_ext(text, Options::empty());
+    let mut bold = false;
+    let mut italic = false;
+    let mut in_link = false;
+    let mut link_url_str: Option<String> = None;
+    let mut link_hyperlink_opened = false;
+    let mut visible_pos = 0usize;
+    let end = skip + limit;
+
+    for event in parser {
+        if visible_pos >= end {
+            break;
+        }
+        match event {
+            Event::Start(Tag::Emphasis) => italic = true,
+            Event::Start(Tag::Strong) => bold = true,
+            Event::Start(Tag::Link { dest_url, .. }) => {
+                in_link = true;
+                link_url_str = Some(dest_url.to_string());
+                link_hyperlink_opened = false;
+                // Open hyperlink eagerly when already in the visible range
+                if visible_pos >= skip && c.atty && c.color_term != fmt::TermColorType::None {
+                    stdout.set_hyperlink(&HyperlinkSpec::open(dest_url.as_bytes()))?;
+                    link_hyperlink_opened = true;
+                }
+            }
+            Event::End(TagEnd::Emphasis) => italic = false,
+            Event::End(TagEnd::Strong) => bold = false,
+            Event::End(TagEnd::Link) => {
+                if link_hyperlink_opened && c.atty && c.color_term != fmt::TermColorType::None {
+                    stdout.set_hyperlink(&HyperlinkSpec::close())?;
+                }
+                in_link = false;
+                link_url_str = None;
+                link_hyperlink_opened = false;
+            }
+            Event::Code(t) => {
+                for ch in t.chars() {
+                    if visible_pos >= end {
+                        break;
+                    }
+                    if visible_pos >= skip {
+                        let code_color = merge_md_style(&c.colors.code, bold, italic, in_link);
+                        stdout.set_color(&code_color)?;
+                        write!(stdout, "{ch}")?;
+                    }
+                    visible_pos += 1;
+                }
+            }
+            Event::Text(t) => {
+                // Compute the slice of text that falls in our range
+                let text_start = visible_pos;
+                let text_chars: Vec<char> = t.chars().collect();
+                let text_end = text_start + text_chars.len();
+
+                if text_end <= skip || text_start >= end {
+                    // Entirely outside our range
+                    visible_pos += text_chars.len();
+                    continue;
+                }
+
+                let range_start = skip.saturating_sub(text_start);
+                let range_end = if text_end > end { end - text_start } else { text_chars.len() };
+                let slice: String = text_chars[range_start..range_end].iter().collect();
+
+                if in_link {
+                    // Lazy-open hyperlink when the link straddles the skip boundary
+                    if !link_hyperlink_opened
+                        && c.atty
+                        && c.color_term != fmt::TermColorType::None
+                        && let Some(ref url) = link_url_str
+                    {
+                        stdout.set_hyperlink(&HyperlinkSpec::open(url.as_bytes()))?;
+                        link_hyperlink_opened = true;
+                    }
+                    let merged = merge_md_style(base, bold, italic, true);
+                    stdout.set_color(&merged)?;
+                    write!(stdout, "{slice}")?;
+                } else {
+                    write_text_with_syntax(stdout, &slice, base, bold, italic, false, c)?;
+                }
+                visible_pos += text_chars.len();
+            }
+            Event::SoftBreak | Event::HardBreak => {
+                if visible_pos >= skip && visible_pos < end {
+                    write!(stdout, " ")?;
+                }
+                visible_pos += 1;
+            }
+            _ => {}
+        }
+    }
+
+    // Close any open hyperlink if we broke out of the loop mid-link
+    if in_link && link_hyperlink_opened && c.atty && c.color_term != fmt::TermColorType::None {
+        stdout.set_hyperlink(&HyperlinkSpec::close())?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn visible_text_bold() {
+        assert_eq!(visible_text("**bold**"), "bold");
+    }
+
+    #[test]
+    fn visible_text_italic() {
+        assert_eq!(visible_text("*italic*"), "italic");
+    }
+
+    #[test]
+    fn visible_text_code() {
+        assert_eq!(visible_text("`code`"), "code");
+    }
+
+    #[test]
+    fn visible_text_link() {
+        assert_eq!(visible_text("[label](https://example.com)"), "label");
+    }
+
+    #[test]
+    fn visible_text_plain() {
+        assert_eq!(visible_text("plain text"), "plain text");
+    }
+
+    #[test]
+    fn visible_text_unmatched_star() {
+        assert_eq!(visible_text("a * b"), "a * b");
+    }
+
+    #[test]
+    fn visible_text_underscore_tag() {
+        // CommonMark flanking rules: underscores within words don't trigger emphasis
+        assert_eq!(visible_text("due_date:2024-01-01"), "due_date:2024-01-01");
+    }
+
+    #[test]
+    fn visible_text_bold_italic() {
+        assert_eq!(visible_text("***both***"), "both");
+    }
+
+    #[test]
+    fn visible_text_mixed() {
+        assert_eq!(visible_text("**bold** and *italic* and `code`"), "bold and italic and code");
+    }
+}

--- a/src/md.rs
+++ b/src/md.rs
@@ -4,7 +4,7 @@
 //! bold, italic, inline code, and links — with optional OSC 8 hyperlinks
 //! and syntax highlighting of `+projects`, `@contexts`, and `tag:value` fields.
 
-use std::io;
+use std::io::{self, Write};
 use std::sync::OnceLock;
 
 use pulldown_cmark::{Event, Options, Parser, Tag, TagEnd};
@@ -16,6 +16,18 @@ use crate::fmt;
 fn bare_url_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| Regex::new(r"https?://\S+").unwrap())
+}
+
+/// Strips common trailing punctuation characters from a bare URL match.
+///
+/// Greedy `\S+` can absorb trailing `.`, `,`, `)`, etc. that belong to the
+/// surrounding prose.  This helper peels them off so only the URL is linked.
+/// Returns `(url, trailing)` where `trailing` is the stripped suffix.
+fn trim_url_punctuation(url: &str) -> (&str, &str) {
+    let trim_chars: &[char] = &['.', ',', ')', ']', '!', '?', ';', ':'];
+    let trimmed = url.trim_end_matches(trim_chars);
+    let trailing = &url[trimmed.len()..];
+    (trimmed, trailing)
 }
 
 /// Returns the visible text that a terminal would display after markdown rendering.
@@ -84,6 +96,7 @@ fn write_text_with_syntax(
 }
 
 /// Writes text, wrapping bare URLs in OSC 8 hyperlinks when running in a terminal.
+/// Trailing punctuation is stripped from matched URLs and printed as plain text.
 fn write_text_with_urls(stdout: &mut StandardStream, text: &str, color: &ColorSpec, c: &fmt::Conf) -> io::Result<()> {
     if !c.atty || c.color_term == fmt::TermColorType::None {
         stdout.set_color(color)?;
@@ -97,13 +110,17 @@ fn write_text_with_urls(stdout: &mut StandardStream, text: &str, color: &ColorSp
             stdout.set_color(color)?;
             write!(stdout, "{}", &text[last..m.start()])?;
         }
-        let url = m.as_str();
+        let (url, trailing) = trim_url_punctuation(m.as_str());
         let mut url_color = color.clone();
         url_color.set_underline(true);
         stdout.set_hyperlink(&HyperlinkSpec::open(url.as_bytes()))?;
         stdout.set_color(&url_color)?;
         write!(stdout, "{url}")?;
         stdout.set_hyperlink(&HyperlinkSpec::close())?;
+        if !trailing.is_empty() {
+            stdout.set_color(color)?;
+            write!(stdout, "{trailing}")?;
+        }
         last = m.end();
     }
     if last < text.len() {
@@ -332,5 +349,35 @@ mod tests {
     #[test]
     fn visible_text_mixed() {
         assert_eq!(visible_text("**bold** and *italic* and `code`"), "bold and italic and code");
+    }
+
+    // ── trim_url_punctuation ──────────────────────────────────────────────────
+
+    #[test]
+    fn trim_url_trailing_period() {
+        let (url, trailing) = trim_url_punctuation("https://example.com.");
+        assert_eq!(url, "https://example.com");
+        assert_eq!(trailing, ".");
+    }
+
+    #[test]
+    fn trim_url_trailing_paren_comma() {
+        let (url, trailing) = trim_url_punctuation("https://example.com),");
+        assert_eq!(url, "https://example.com");
+        assert_eq!(trailing, "),");
+    }
+
+    #[test]
+    fn trim_url_no_trailing_punctuation() {
+        let (url, trailing) = trim_url_punctuation("https://example.com/path");
+        assert_eq!(url, "https://example.com/path");
+        assert_eq!(trailing, "");
+    }
+
+    #[test]
+    fn trim_url_query_string() {
+        let (url, trailing) = trim_url_punctuation("https://example.com/path?q=1");
+        assert_eq!(url, "https://example.com/path?q=1");
+        assert_eq!(trailing, "");
     }
 }

--- a/src/md.rs
+++ b/src/md.rs
@@ -171,6 +171,10 @@ pub fn print_markdown(stdout: &mut StandardStream, text: &str, base: &ColorSpec,
 /// Skips the first `skip` visible characters, then renders up to `limit`
 /// visible characters. Used for wrapped/cut lines: line 1 uses skip=0,
 /// line 2 uses skip=len(line1), etc.
+///
+/// Note: when `skip` or `limit` bisects a bare URL, the halves are rendered
+/// as plain text rather than hyperlinks.  This is a known limitation of the
+/// character-offset slicing approach; the output is visually correct.
 pub fn print_markdown_range(
     stdout: &mut StandardStream,
     text: &str,

--- a/src/md.rs
+++ b/src/md.rs
@@ -4,12 +4,12 @@
 //! bold, italic, inline code, and links — with optional OSC 8 hyperlinks
 //! and syntax highlighting of `+projects`, `@contexts`, and `tag:value` fields.
 
-use std::io::{self, Write};
+use std::io;
 use std::sync::OnceLock;
 
 use pulldown_cmark::{Event, Options, Parser, Tag, TagEnd};
 use regex::Regex;
-use termcolor::{ColorSpec, HyperlinkSpec, StandardStream, WriteColor};
+use termcolor::{ColorSpec, HyperlinkSpec, WriteColor};
 
 use crate::fmt;
 
@@ -63,8 +63,8 @@ fn merge_md_style(base: &ColorSpec, bold: bool, italic: bool, underline: bool) -
 
 /// Writes `text` with syntax highlighting (projects, contexts, tags, hashtags)
 /// while preserving bold/italic/underline from the markdown stack.
-fn write_text_with_syntax(
-    stdout: &mut StandardStream,
+fn write_text_with_syntax<W: WriteColor>(
+    stdout: &mut W,
     text: &str,
     base: &ColorSpec,
     bold: bool,
@@ -97,7 +97,7 @@ fn write_text_with_syntax(
 
 /// Writes text, wrapping bare URLs in OSC 8 hyperlinks when running in a terminal.
 /// Trailing punctuation is stripped from matched URLs and printed as plain text.
-fn write_text_with_urls(stdout: &mut StandardStream, text: &str, color: &ColorSpec, c: &fmt::Conf) -> io::Result<()> {
+fn write_text_with_urls<W: WriteColor>(stdout: &mut W, text: &str, color: &ColorSpec, c: &fmt::Conf) -> io::Result<()> {
     if !c.atty || c.color_term == fmt::TermColorType::None {
         stdout.set_color(color)?;
         write!(stdout, "{text}")?;
@@ -134,7 +134,7 @@ fn write_text_with_urls(stdout: &mut StandardStream, text: &str, color: &ColorSp
 ///
 /// Supports bold, italic, inline code, links, and bare URLs.
 /// When `c.syntax` is true, also highlights +projects, @contexts, #hashtags, and tags.
-pub fn print_markdown(stdout: &mut StandardStream, text: &str, base: &ColorSpec, c: &fmt::Conf) -> io::Result<()> {
+pub fn print_markdown<W: WriteColor>(stdout: &mut W, text: &str, base: &ColorSpec, c: &fmt::Conf) -> io::Result<()> {
     let parser = Parser::new_ext(text, Options::empty());
     let mut bold = false;
     let mut italic = false;
@@ -192,8 +192,8 @@ pub fn print_markdown(stdout: &mut StandardStream, text: &str, base: &ColorSpec,
 /// Note: when `skip` or `limit` bisects a bare URL, the halves are rendered
 /// as plain text rather than hyperlinks.  This is a known limitation of the
 /// character-offset slicing approach; the output is visually correct.
-pub fn print_markdown_range(
-    stdout: &mut StandardStream,
+pub fn print_markdown_range<W: WriteColor>(
+    stdout: &mut W,
     text: &str,
     skip: usize,
     limit: usize,
@@ -304,6 +304,9 @@ pub fn print_markdown_range(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use termcolor::{Buffer, ColorSpec};
+
+    // ── visible_text ──────────────────────────────────────────────────────────
 
     #[test]
     fn visible_text_bold() {
@@ -351,6 +354,78 @@ mod tests {
         assert_eq!(visible_text("**bold** and *italic* and `code`"), "bold and italic and code");
     }
 
+    #[test]
+    fn visible_text_empty() {
+        assert_eq!(visible_text(""), "");
+    }
+
+    #[test]
+    fn visible_text_nested_formatting() {
+        assert_eq!(visible_text("**bold *and italic***"), "bold and italic");
+    }
+
+    #[test]
+    fn visible_text_soft_break() {
+        // pulldown-cmark emits SoftBreak between lines; visible_text renders it as a space
+        assert_eq!(visible_text("line one\nline two"), "line one line two");
+    }
+
+    #[test]
+    fn visible_text_multiple_links() {
+        assert_eq!(visible_text("[first](https://a.com) and [second](https://b.com)"), "first and second");
+    }
+
+    #[test]
+    fn visible_text_bare_url() {
+        // Bare URLs are plain text to the parser; they pass through unchanged
+        assert_eq!(visible_text("see https://example.com for details"), "see https://example.com for details");
+    }
+
+    // ── merge_md_style ────────────────────────────────────────────────────────
+
+    #[test]
+    fn merge_md_style_bold() {
+        let base = ColorSpec::new();
+        let result = merge_md_style(&base, true, false, false);
+        assert!(result.bold());
+        assert!(!result.italic());
+        assert!(!result.underline());
+    }
+
+    #[test]
+    fn merge_md_style_italic() {
+        let base = ColorSpec::new();
+        let result = merge_md_style(&base, false, true, false);
+        assert!(!result.bold());
+        assert!(result.italic());
+    }
+
+    #[test]
+    fn merge_md_style_underline() {
+        let base = ColorSpec::new();
+        let result = merge_md_style(&base, false, false, true);
+        assert!(result.underline());
+    }
+
+    #[test]
+    fn merge_md_style_all_flags() {
+        let base = ColorSpec::new();
+        let result = merge_md_style(&base, true, true, true);
+        assert!(result.bold());
+        assert!(result.italic());
+        assert!(result.underline());
+    }
+
+    #[test]
+    fn merge_md_style_preserves_base_color() {
+        use termcolor::Color;
+        let mut base = ColorSpec::new();
+        base.set_fg(Some(Color::Red));
+        let result = merge_md_style(&base, true, false, false);
+        assert_eq!(result.fg(), Some(&Color::Red));
+        assert!(result.bold());
+    }
+
     // ── trim_url_punctuation ──────────────────────────────────────────────────
 
     #[test]
@@ -379,5 +454,90 @@ mod tests {
         let (url, trailing) = trim_url_punctuation("https://example.com/path?q=1");
         assert_eq!(url, "https://example.com/path?q=1");
         assert_eq!(trailing, "");
+    }
+
+    // ── print_markdown output tests ───────────────────────────────────────────
+
+    fn make_conf() -> fmt::Conf {
+        fmt::Conf { atty: false, ..Default::default() }
+    }
+
+    fn render_markdown(text: &str) -> String {
+        let mut buf = Buffer::no_color();
+        let base = ColorSpec::new();
+        let c = make_conf();
+        print_markdown(&mut buf, text, &base, &c).unwrap();
+        String::from_utf8(buf.into_inner()).unwrap()
+    }
+
+    #[test]
+    fn print_markdown_plain_text() {
+        assert_eq!(render_markdown("hello world"), "hello world");
+    }
+
+    #[test]
+    fn print_markdown_bold() {
+        // Bold markers are consumed; visible text is the inner content
+        assert_eq!(render_markdown("**bold**"), "bold");
+    }
+
+    #[test]
+    fn print_markdown_italic() {
+        assert_eq!(render_markdown("*italic*"), "italic");
+    }
+
+    #[test]
+    fn print_markdown_code() {
+        assert_eq!(render_markdown("`code`"), "code");
+    }
+
+    #[test]
+    fn print_markdown_link() {
+        // Link label is the visible text; dest_url is only in hyperlink escape
+        assert_eq!(render_markdown("[label](https://example.com)"), "label");
+    }
+
+    #[test]
+    fn print_markdown_mixed() {
+        assert_eq!(render_markdown("**bold** and *italic*"), "bold and italic");
+    }
+
+    // ── print_markdown_range output tests ────────────────────────────────────
+
+    fn render_range(text: &str, skip: usize, limit: usize) -> String {
+        let mut buf = Buffer::no_color();
+        let base = ColorSpec::new();
+        let c = make_conf();
+        print_markdown_range(&mut buf, text, skip, limit, &base, &c).unwrap();
+        String::from_utf8(buf.into_inner()).unwrap()
+    }
+
+    #[test]
+    fn print_markdown_range_full() {
+        let text = "hello world";
+        let full = render_markdown(text);
+        let range = render_range(text, 0, full.chars().count());
+        assert_eq!(full, range);
+    }
+
+    #[test]
+    fn print_markdown_range_skip() {
+        // Skip first 6 chars of "hello world" → "world"
+        let result = render_range("hello world", 6, 5);
+        assert_eq!(result, "world");
+    }
+
+    #[test]
+    fn print_markdown_range_cut_through_formatted() {
+        // "**bold** text" → visible "bold text"; take first 4 chars → "bold"
+        let result = render_range("**bold** text", 0, 4);
+        assert_eq!(result, "bold");
+    }
+
+    #[test]
+    fn print_markdown_range_second_line() {
+        // "bold text" visible; skip 4 → " text"
+        let result = render_range("**bold** text", 4, 5);
+        assert_eq!(result, " text");
     }
 }

--- a/src/tml.rs
+++ b/src/tml.rs
@@ -52,7 +52,9 @@ pub struct Syntax {
 
 #[derive(Deserialize)]
 pub struct Markdown {
+    #[cfg_attr(not(feature = "markdown"), allow(dead_code))]
     pub enabled: Option<bool>,
+    #[cfg_attr(not(feature = "markdown"), allow(dead_code))]
     pub code_color: Option<String>,
 }
 
@@ -86,6 +88,7 @@ pub struct Conf {
     pub ranges: Ranges,
     pub global: Global,
     pub syntax: Option<Syntax>,
+    #[cfg_attr(not(feature = "markdown"), allow(dead_code))]
     pub markdown: Option<Markdown>,
     pub fields: Option<Vec<CustomField>>,
     pub agenda: Option<Agenda>,

--- a/src/tml.rs
+++ b/src/tml.rs
@@ -51,6 +51,12 @@ pub struct Syntax {
 }
 
 #[derive(Deserialize)]
+pub struct Markdown {
+    pub enabled: Option<bool>,
+    pub code_color: Option<String>,
+}
+
+#[derive(Deserialize)]
 pub struct CustomRule {
     pub range: String,
     pub color: String,
@@ -80,6 +86,7 @@ pub struct Conf {
     pub ranges: Ranges,
     pub global: Global,
     pub syntax: Option<Syntax>,
+    pub markdown: Option<Markdown>,
     pub fields: Option<Vec<CustomField>>,
     pub agenda: Option<Agenda>,
 }

--- a/ttdl.toml
+++ b/ttdl.toml
@@ -181,6 +181,14 @@ hashtag_color = "cyan"
 project_color = "bright green"
 context_color = "green"
 
+[markdown]
+# Set enabled to 'true' to render Markdown formatting (bold, italic, code,
+#     links) in task subject text using terminal escape codes.
+# Bold, italic, inline code, and [links](url) are supported.
+# enabled = false
+# Color for inline `code` spans. Same format as other color options.
+# code_color = "yellow"
+
 # Example of a custom field of `date` type with conditional highlight.
 # [[fields]]
 # name = "chk" # tag name


### PR DESCRIPTION
## Summary

Addresses #103. Adds terminal Markdown rendering for task subject text, gated behind a Cargo feature flag that is **on by default**.

- `*italic*`, `**bold**`, `` `code` ``, `[links](url)` rendered as ANSI escape sequences
- Bare `https://` / `http://` URLs wrapped in OSC 8 hyperlinks; trailing punctuation (`.`, `,`, `)`, …) correctly stripped from matches
- Syntax highlighting of `+projects`, `@contexts`, `tag:value` fields works alongside Markdown formatting
- Off by default at runtime; opt in with `--markdown` or `[markdown] enabled = true` in `ttdl.toml`
- Built on `pulldown-cmark` (CommonMark-compliant parser)

**Feature flag** (per #103 review request):

```toml
# Cargo.toml
[features]
default = ["markdown"]
markdown = ["dep:pulldown-cmark"]
```

Build without the dependency:
```shell
cargo install ttdl --no-default-features
```
When built without the feature, `--markdown` is accepted but has no effect.

## Commits

1. **[Feat] Render Markdown subset as ANSI in task subjects** — core rendering, `--markdown` flag, `[markdown]` config section, README docs
2. **[Feat] Gate markdown rendering behind a Cargo feature flag** — `optional = true` on `pulldown-cmark`, all `#[cfg(feature = "markdown")]` guards, README install note
3. **[Fix] Trim trailing punctuation from bare URL matches** — `\S+` greedily absorbed `.`, `,`, `)` etc.; `trim_url_punctuation()` peels them off before the OSC 8 hyperlink
4. **[Test] Expand markdown module test coverage** — functions made generic over `W: WriteColor` to enable `Buffer`-based tests; covers `visible_text` edge cases, `merge_md_style`, `trim_url_punctuation`, and full `print_markdown` / `print_markdown_range` output

## Test plan

- [ ] `cargo test --verbose` — all tests pass
- [ ] `cargo test --no-default-features --verbose` — compiles and passes (md tests excluded)
- [ ] `cargo clippy` / `cargo clippy --no-default-features` — no warnings
- [ ] `cargo fmt --check` — clean
- [ ] Manual: `ttdl list --markdown` renders bold/italic/code/links in a terminal that supports ANSI
- [ ] Manual: bare URL in subject gets OSC 8 hyperlink; trailing period not included in the link